### PR TITLE
 📝 Update tauri template

### DIFF
--- a/tauri/flake.nix
+++ b/tauri/flake.nix
@@ -18,7 +18,7 @@
     utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [fenix.overlay];
+        overlays = [fenix.overlays.default];
       };
       toolchain = pkgs.fenix.complete;
       buildInputs = with pkgs; [


### PR DESCRIPTION
Update nixpkgs overlays according to logs

```
trace: warning: `fenix.overlay` is deprecated; use 'fenix.overlays.default' instead
```